### PR TITLE
Revert b alias to just plain branch

### DIFF
--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -28,7 +28,7 @@
 
 	co = checkout
 
-    #b = branch
+    b = branch
     s = status
     d = diff
     dt = difftool
@@ -46,7 +46,7 @@
     # clean up merged branches except current branch, master, or dev
     cleanup = "!git branch --merged | grep  -v '\\*\\|master\\|dev' | xargs -n 1 git branch -d"
 
-    b = "!. ~/.githelpers && pretty_git_branch"
+    bp = "!. ~/.githelpers && pretty_git_branch"
     bs = "!. ~/.githelpers && pretty_git_branch_sorted"
 
     # Divergence (commits we added and commits remote added)


### PR DESCRIPTION
Made bp be the alias to Gbernhardt's pretty branch output.  Problem
was that using his alias as b meant I lost tab completion on doing
a "git b <tab>", and I use "git b <tab>" A LOT.