### PR TITLE
Add git stash drop alias

### DIFF
--- a/dotfiles/.gitconfig
+++ b/dotfiles/.gitconfig
@@ -66,6 +66,7 @@
     psom = push origin master
     plom = pull origin master
     plod = syncdev
+    stashdropbecarefulbecausethisisdangerous = !sh -c 'git stash && git stash drop'
 
 [github]
 	user = pzelnip


### PR DESCRIPTION
I find I do:

```
git stash ; git stash drop
```

to turf all uncommitted changes fairly often.  Adding an alias for this.  Making the alias obnoxiously long to encourage sanity checking use (tab completion means I still type `git stashd<TAB>` so no difference in keystrokes.